### PR TITLE
Add build-and-push image workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,39 @@
+name: Publish Docker Image
+
+on:
+  push:
+    brnaches:
+      - master
+      - develop
+
+jobs:
+  push_to_registry:
+    name: Push image to Docker Hub
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          pull: true
+          push: true
+          cache-from: type=registry,ref=usccsci104/docker:latest
+          cache-to: type=inline
+          tags: usccsci104/docker:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
PR for visibility since this is a relatively new change to the repo.

Build and push to DockerHub when commits are pushed to `origin/develop` and `origin/master`