### PR TITLE
Use ubuntu version over latest tag. Closes #13

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -30,7 +30,7 @@ jobs:
           file: ./Dockerfile
           pull: true
           push: true
-          tags: usccsci104/docker:latest
+          tags: usccsci104/docker:20.04
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/unix/setup.sh
+++ b/unix/setup.sh
@@ -32,7 +32,7 @@ echo "Mount point set, this can be changed later by editing $HOME/.ch.yaml..."
 
 # Create csci104 environment with ch CLI
 echo "Creating csci104 environment..."
-ch create csci104 --image usccsci104/docker:latest --shell /bin/bash --volume "$work:/work" --security-opt seccomp:unconfined --cap-add SYS_PTRACE --replace
+ch create csci104 --image usccsci104/docker:20.04 --shell /bin/bash --volume "$work:/work" --security-opt seccomp:unconfined --cap-add SYS_PTRACE --replace
 
 echo "Done!"
 

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -33,4 +33,4 @@ Write-Output "Mount point set, this can be changed later by editing $conf_path"
 
 # Create csci104 environment with ch CLI
 Write-Output "Creating csci104 environment..."
-ch create csci104 --image usccsci104/docker:latest --shell /bin/bash --volume ("{0}:/work" -f $work) --security-opt seccomp:unconfined --cap-add SYS_PTRACE --replace
+ch create csci104 --image usccsci104/docker:20.04 --shell /bin/bash --volume ("{0}:/work" -f $work) --security-opt seccomp:unconfined --cap-add SYS_PTRACE --replace


### PR DESCRIPTION
Use ubuntu version `20.04` over `latest` Docker tag when building in CI and pulling image in setup scripts. Closes #13.