### PR TITLE
Rewrite README.md with steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,19 @@ Docker is considerably less resource-intensive than installing a full virtual ma
 Instead of needing the facilities for a graphical interface, virtual file system, etc., we can mount any directory of the host machine directly in the container and use a shell to run compilation and debugging.
 Development and file management may be done normally on the local machine.
 
-The rest of this README is a quickstart for more experienced users.
 Feel free to read through the [wiki](https://github.com/csci104/docker/wiki) for **a more in-depth guide on [how setup and use Docker](https://github.com/csci104/docker/wiki/Usage)** as well as [how it works](https://github.com/csci104/docker/wiki/Details).
 
 ## Installation
 ### Prerequisites
 
-Below are the system requirements for Docker Desktop:
+Please make sure that your machine meets the requirements for Docker Desktop, which you will install in [Step 1](#step-1-install-docker):
 
 [Windows host](https://docs.docker.com/docker-for-windows/install/):
 
 - Windows 10 64-bit: (Build 18362 or later)
   - WSL2 container backend
 
-> **Optional:** If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education [here](https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/) though this is not required.
+> **Optional:** If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education [here](https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/).
 
 [Mac host](https://docs.docker.com/docker-for-mac/install/):
 
@@ -49,7 +48,7 @@ Below are the system requirements for Docker Desktop:
     here](https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/)
     to run Terminal through Rosetta.
 
-> **Note:** gdb may not work on Apple Silicon per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
+> **Note:** The gdb debugger used in CSCI104 may not work on Apple Silicon per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
 
 ### Step 0: Install WSL2 (Windows only)
 
@@ -64,28 +63,42 @@ Follow the instructions below to install WSL2 on your machine: [Windows Subsyste
 
 Install Docker Desktop from [the website](https://www.docker.com/products/docker-desktop).
 
-### Step 2: Clone this repository
+### Step 2: Create a working directory
 
-After setting up Docker you need to clone this repository which contains
+We highly recommend that you create a dedicated working directory to clone CSCI 104
+repositories and to do your programming assignments.
+
+Create a `csci104` folder on your machine. Next, you'll need to open a terminal into
+the folder to run the remaining commands in the setup.
+
+Open up a Terminal (macOS) or Powershell/Windows Terminal (Windows). Next, navigate
+to your `csci104` folder by typing `cd ` (notice the space) and dragging the
+`csci104` folder from Finder or File Explorer into the terminal, then pressing enter.
+
+### Step 3: Clone this repository
+
+After setting up Docker, you need to clone this repository which contains
 a setup script for both Windows and Unix-based systems.
 
-You can clone the repository with this command:
+
+Run the commands below to clone the repository and change directories into the new folder:
 
 ```shell
 git clone git@github.com:csci104/docker.git
+cd docker
 ```
 
 If this command fails with an error like `git command not found`, you need to
 install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads) and download
 the package for your operating system.
 
-### Step 3: Run the setup script
+### Step 4: Run the setup script
 
 This repository contains a setup script to install a command-line tool you will
 use to access your Docker containers, pull the CSCI 104 docker image and setup your virtualized environment.
 
-To run the setup script, you need to open a Terminal or Powershell into the `docker` repository you cloned in [Step 2](#step-2-clone-this-repository).
-If you're not sure how to do that, see the [Getting a Filepath](#getting-a-filepath) tip.
+If you followed [Step 3](#step-3-clone-this-repository) properly, you have a terminal open
+in the docker folder. If you're not sure, see the [Filepaths in the Terminal](#filepaths-in-the-terminal) tip.
 
 Now that you're ready to run the setup script, read and follow the instructions
 below corresponding to your operating system:
@@ -98,7 +111,8 @@ On macOS in Terminal, run the respective setup script inside the `docker` folder
 ./unix/setup.sh
 ```
 
-Note: if you're not able to run `ch` after setup, you may need to run `source ~/.zprofile` or `source ~/.bash_profile` depending on your shell.
+> Note: if you're not able to run `ch` after setup, you may need to run `source ~/.zshrc` or `source ~/.bashrc` depending on your default shell. If you don't understand what this means,
+you can safely ignore the comment!
 
 **Windows**
 
@@ -121,13 +135,9 @@ In PowerShell, run this command in the `docker` folder:
 
 If the command above runs successfully, you will be prompted to provide the directory in your local machine you wish to be accessible from the virtual machine.
 
-We highly recommend that you create a specific `csci104` folder where you will clone the required
-repositories and complete your programming assignments for the class.
-
-If you made your `csci104` folder in your home directory, the path will look something like
-this: `/Users/username/csci104` (macOS) or `C:\Users\username\csci104` (Windows).
-
-To get the filepath to this folder, you can drag the `csci104` folder into your terminal from Finder/Explorer. See the [Getting a Filepath](#getting-a-filepath) tip for more help.
+If you followed [Step 2](#step-2-create-a-working-directory), you will drag the
+`csci104` folder you created into your terminal from Finder/File Explorer. See
+the [Filepaths in the Terminal](#filepaths-in-the-terminal) tip for more help.
 
 
 ### Step 5: Verify your installation
@@ -139,7 +149,8 @@ If this fails, try opening up a new terminal and retry the command. If this fail
 ask a CP, post on Piazza, or [create a Github Issue](https://github.com/csci104/docker/issues/new/choose) if you're not in the class but still need help.
 
 Let's check and make sure everything works by running `ch list` in your terminal.
-You should get output like this below:
+You should get output like this below, but don't worry if the filepath in `Volume`
+looks a little different:
 
 **macOS**
 
@@ -163,6 +174,7 @@ Name:   csci104
         CapAdd: SYS_PTRACE
 ```
 
+If you see output something like this, you're all set up! Congrats!
 
 ## Working
 
@@ -201,20 +213,20 @@ ch stop csci104
 
 ## Tips
 
-### Getting a Filepath
+### Filepaths in the terminal
 
 For the installation script and when navigating your terminal for the first time,
-you might need to provide a filepath. This represents "where" on your machine
+you might need to provide a filepath. This represents where on your machine
 a specific folder or file is located.
 
 There are many ways to do this, but this seems like the easiest way for
 people getting used to using their terminal:
 
-1. open Finder (macOS) or Explorer (Windows)
+1. open Finder (macOS) or File Explorer (Windows)
 2. find the folder where you want to go to
 3. drag the path into your terminal to get the path
 
-If you're wanting to change directories like in [Step 2](#step-2-clone-this-repository), you'll type "cd " into your terminal and
+If you're wanting to change directories like in [Step 2](#step-2-clone-this-repository), you'll type `cd ` into your terminal and
 drag the folder in.
 
 If you're running the setup script in [Step 3](#step-3-run-the-setup-script), you will drag your csci104 folder in the terminal

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Development and file management may be done normally on the local machine.
 Feel free to read through the [wiki](https://github.com/csci104/docker/wiki) for **a more in-depth guide on [how setup and use Docker](https://github.com/csci104/docker/wiki/Usage)** as well as [how it works](https://github.com/csci104/docker/wiki/Details).
 
 ## Installation
+
+This is a fairly long wiki in order to be as clear as possible. Feel free to jump around using the Table of Contents icon on the upper left side of this README:
+
+<div align="center">
+  <img width="300px" alt="screenshot of github table of contents list" src="https://user-images.githubusercontent.com/17013462/118037619-f411cf80-b322-11eb-8278-437177650ed5.png" />
+</div>
+
+
+
 ### Prerequisites
 
 You will be running a lot of commands in the terminal to set this up. If you have not done
@@ -69,7 +78,10 @@ Install Docker Desktop from <a href="https://www.docker.com/products/docker-desk
 When the installation has finished, open up Docker Desktop to make sure it's running. If Docker is running
 properly, you will see a green icon in the lower left side, like the image below:
 
-<img src="https://user-images.githubusercontent.com/17013462/117899471-08e75800-b27c-11eb-88f4-72c8c4586630.png" width="650px">
+<div align="center">
+  <img width="650px" src="https://user-images.githubusercontent.com/17013462/117899471-08e75800-b27c-11eb-88f4-72c8c4586630.png" alt="screenshot of Docker Desktop with a green icon on the lower left side">
+</div>
+
 
 
 If you encounter errors in this process, please see the <a href="https://github.com/csci104/docker/wiki/Troubleshooting" target="_blank">Troubleshooting wiki</a>.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the folder to run the remaining commands in the setup.
 
 Open up a Terminal (macOS) or Powershell/Windows Terminal (Windows). Next, navigate
 to your `csci104` folder by typing `cd ` (notice the space) and dragging the
-`csci104` folder from Finder or File Explorer into the terminal, then pressing enter.
+`csci104` folder from Finder or File Explorer into the terminal, then press enter.
 
 ### Step 3: Clone this repository
 
@@ -89,8 +89,8 @@ cd docker
 ```
 
 If this command fails with an error like `git command not found`, you need to
-install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads) and download
-the package for your operating system.
+install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads)
+and download the version for your operating system.
 
 ### Step 4: Run the setup script
 
@@ -111,8 +111,8 @@ On macOS in Terminal, run the respective setup script inside the `docker` folder
 ./unix/setup.sh
 ```
 
-> Note: if you're not able to run `ch` after setup, you may need to run `source ~/.zshrc` or `source ~/.bashrc` depending on your default shell. If you don't understand what this means,
-you can safely ignore the comment!
+> Note: if you're not able to run `ch` after setup, you may need to run `source ~/.zshrc` or `source ~/.bashrc`
+> depending on your default shell. If you don't understand what this means, you can safely ignore the comment!
 
 **Windows**
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Specifically, you'll want to look at the [Navigating Directories](https://bytes.
 
 Please make sure that your machine meets the requirements for Docker Desktop, which you will install in [Step 1](#step-1-install-docker):
 
-[Windows host](https://docs.docker.com/docker-for-windows/install/):
+<a href="https://docs.docker.com/docker-for-windows/install/" target="_blank">Windows host:</a>
 
 - Windows 10 64-bit: (Build 18362 or later)
   - WSL2 container backend
 
-> **Optional:** If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education [here](https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/).
+> **Optional:** If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education <a href="https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/">here</a>.
 
-[Mac host](https://docs.docker.com/docker-for-mac/install/):
+<a href="https://docs.docker.com/docker-for-mac/install/" target="_blank">Mac host:</a>
 
 - Intel:
   - Mac hardware must be a 2010 or newer model
@@ -48,8 +48,7 @@ Please make sure that your machine meets the requirements for Docker Desktop, wh
 - Apple Silicon (i.e. M1 chip):
   - Rosetta emulated terminal
     - for instructions on how to setup a Rosetta emulated terminal, see
-    [instructions
-    here](https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/)
+    <a href="https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/" target="_blank">instructions here</a>
     to run Terminal through Rosetta.
 
 > **Note:** The gdb debugger used in CSCI104 may not work on Apple Silicon per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
@@ -59,13 +58,18 @@ Please make sure that your machine meets the requirements for Docker Desktop, wh
 If you are using macOS or Linux operating system, you can skip this section.
 If you are running Windows, you must install the Windows Subsystem for Linux 2 (WSL2) before installing Docker.
 
-Follow the instructions below to install WSL2 on your machine: [Windows Subsystem for Linux Installation Guide](https://docs.microsoft.com/windows/wsl/install-win10)
+Follow the instructions below to install WSL2 on your machine: <a href="https://docs.microsoft.com/windows/wsl/install-win10" target="_blank">Windows Subsystem for Linux Installation Guide</a>
 
 
 ### Step 1: Install Docker
 
 
-Install Docker Desktop from [the website](https://www.docker.com/products/docker-desktop).
+Install Docker Desktop from <a href="https://www.docker.com/products/docker-desktop" target="_blank">the website</a>
+
+When the installation has finished, open up Docker Desktop to make sure it's running. If Docker is running
+properly, you will see a green icon in the lower left side.
+
+If you encounter errors in this process, please see the <a href="https://github.com/csci104/docker/wiki/Troubleshooting" target="_blank">Troubleshooting wiki</a>.
 
 ### Step 2: Create a working directory
 
@@ -93,10 +97,10 @@ cd docker
 ```
 
 If this command fails with an error like `git command not found`, you need to
-install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads)
+install the git command-line interface (CLI). See <a href="https://git-scm.com/downloads" target="_blank">this link</a>
 and download the version for your operating system.
 
-The `git clone` command downloads a repository (think of it as a folder) from the Github URL. To learn more about what the `cd` command does, take a look at the [Linux wiki](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories)
+The `git clone` command downloads a repository (think of it as a folder) from the Github URL. To learn more about what the `cd` command does, take a look at the <a href="https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories" target="_blank">Linux wiki</a>.
 
 ### Step 4: Run the setup script
 
@@ -152,7 +156,8 @@ Once you've finished answering the prompts and setup script finishes, you should
 
 > If you're on macOS, try running `source ~/.zshrc` or `source ~/.bashrc` and then run `ch list`.
 If this fails, try opening up a new terminal and retry the command. If this fails, you can
-ask a CP, post on Piazza, or [create a Github Issue](https://github.com/csci104/docker/issues/new/choose) if you're not in the class but still need help.
+ask a CP, post on Piazza, or <a href="https://github.com/csci104/docker/issues/new/choose" target="_blank">create a Github Issue</a> if
+you're not in the class but still need help.
 
 Let's check and make sure everything works by running `ch list` in your terminal.
 You should get output like this below, but don't worry if the filepath in `Volume`
@@ -212,7 +217,7 @@ This last note deserves some emphasis:
 
 ### Example
 
-See full documentation for `ch` [here](https://github.com/camerondurham/ch).
+See full documentation for `ch` <a href="https://github.com/camerondurham/ch" target="_blank">here</a>.
 
 ```bash
 # start your environment

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In PowerShell, run this command in the `docker` folder:
 .\windows\setup
 ```
 
-### Step 4: Set your working directory
+### Step 5: Set your working directory
 
 If the command above runs successfully, you will be prompted to provide the directory in your local machine you wish to be accessible from the virtual machine.
 
@@ -226,10 +226,10 @@ people getting used to using their terminal:
 2. find the folder where you want to go to
 3. drag the path into your terminal to get the path
 
-If you're wanting to change directories like in [Step 2](#step-2-clone-this-repository), you'll type `cd ` into your terminal and
+If you're wanting to change directories like in [Step 3](#step-3-clone-this-repository), you'll type `cd ` into your terminal and
 drag the folder in.
 
-If you're running the setup script in [Step 3](#step-3-run-the-setup-script), you will drag your csci104 folder in the terminal
+If you're running the setup script in [Step 4](#step-4-run-the-setup-script), you will drag your csci104 folder in the terminal
 when the script asks for a filepath.
 ### Valgrind Suppression
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ Follow the instructions below to install WSL2 on your machine: <a href="https://
 Install Docker Desktop from <a href="https://www.docker.com/products/docker-desktop" target="_blank">the website</a>
 
 When the installation has finished, open up Docker Desktop to make sure it's running. If Docker is running
-properly, you will see a green icon in the lower left side.
+properly, you will see a green icon in the lower left side, like the image below:
+
+<img src="https://user-images.githubusercontent.com/17013462/117899471-08e75800-b27c-11eb-88f4-72c8c4586630.png" width="650px">
+
 
 If you encounter errors in this process, please see the <a href="https://github.com/csci104/docker/wiki/Troubleshooting" target="_blank">Troubleshooting wiki</a>.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Feel free to read through the [wiki](https://github.com/csci104/docker/wiki) for
 ## Installation
 ### Prerequisites
 
+You will be running a lot of commands in the terminal to set this up. If you have not done
+this before, we *highly recommend* checking out CP Jamie Flores' great [Linux](https://bytes.usc.edu/cs104/wiki/linux) wiki.
+Specifically, you'll want to look at the [Navigating Directories](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories) section.
+
 Please make sure that your machine meets the requirements for Docker Desktop, which you will install in [Step 1](#step-1-install-docker):
 
 [Windows host](https://docs.docker.com/docker-for-windows/install/):
@@ -91,6 +95,8 @@ cd docker
 If this command fails with an error like `git command not found`, you need to
 install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads)
 and download the version for your operating system.
+
+To learn more about what the `cd` command does, take a look at the [Linux wiki](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories)
 
 ### Step 4: Run the setup script
 
@@ -191,8 +197,18 @@ There are three commands you will regularly use:
 - The first, `start`, starts the container up in the background.
   The container should continue running until you shut down your computer, exit docker, or kill the container manually.
 - Next is `shell`, which simply opens a shell inside the virtual machine.
-  This is where you can run standard linux commands, such as `g++` or `valgrind`. You can exit the shell with the key sequence <Ctrl+D> <Ctrl+C>.
+  This is where you can run standard linux commands, such as `g++` or `valgrind`. You can exit the shell with the key sequence <Ctrl+D>
 - The last is `stop`, which manually shuts down the virtual container.
+
+
+You will use the `ch shell csci104` command to access the Docker container and compile or execute your code and run the
+autograder tests after assignments are graded. Anytime you need to push code to Github, make sure to exit the container.
+This last note deserves some emphasis:
+
+
+> **You should not run any git commands in Docker**. This means you shouldn't
+> run `git pull`, `git push`, `git clone`, etc after running `ch shell csci104`.
+
 
 ### Example
 
@@ -205,7 +221,7 @@ ch start csci104
 # get a shell into the csci104 environment
 ch shell csci104
 
-# exit the shell with key sequence <Ctrl+D> <Ctrl+C>
+# exit the shell with <Ctrl+D> or typing `exit`
 
 # stop the running environment
 ch stop csci104
@@ -215,9 +231,11 @@ ch stop csci104
 
 ### Filepaths in the terminal
 
-For the installation script and when navigating your terminal for the first time,
-you might need to provide a filepath. This represents where on your machine
-a specific folder or file is located.
+For the installation script and when navigating your terminal for the first
+time, you might need to provide a filepath. This represents where on your
+machine a specific folder or file is located. For more about this and
+terminal commands in general, please check out the
+[Linux wiki](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories).
 
 There are many ways to do this, but this seems like the easiest way for
 people getting used to using their terminal:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If this command fails with an error like `git command not found`, you need to
 install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads)
 and download the version for your operating system.
 
-To learn more about what the `cd` command does, take a look at the [Linux wiki](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories)
+The `git clone` command downloads a repository (think of it as a folder) from the Github URL. To learn more about what the `cd` command does, take a look at the [Linux wiki](https://bytes.usc.edu/cs104/wiki/linux/#navigating-directories)
 
 ### Step 4: Run the setup script
 
@@ -206,7 +206,7 @@ autograder tests after assignments are graded. Anytime you need to push code to 
 This last note deserves some emphasis:
 
 
-> **You should not run any git commands in Docker**. This means you shouldn't
+> **You should not run any git commands in Docker**. This means you should not
 > run `git pull`, `git push`, `git clone`, etc after running `ch shell csci104`.
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 </br>
 
+## Introduction
+
 This repository contains a Dockerfile and a couple of management scripts for creating and using a virtualized Linux container capable of building, running, and debugging C++.
 Using a virtualized container is preferable to a user's local machine because it guarantees consistent compilation and execution of C++ binaries.
 While compilers and tooling may vary between systems, creating a sealed environment from the exact same components every time ensures that code runs the same for graders as it does students.
@@ -22,33 +24,71 @@ Development and file management may be done normally on the local machine.
 The rest of this README is a quickstart for more experienced users.
 Feel free to read through the [wiki](https://github.com/csci104/docker/wiki) for **a more in-depth guide on [how setup and use Docker](https://github.com/csci104/docker/wiki/Usage)** as well as [how it works](https://github.com/csci104/docker/wiki/Details).
 
-## System Requirements
+## Installation
+### Prerequisites
 
 Below are the system requirements for Docker Desktop:
 
 [Windows host](https://docs.docker.com/docker-for-windows/install/):
 
-- Windows 10 64-bit: (Build 15063 or later)
-  - Pro, Enterprise, or Education: using Hyper-V and Containers Windows features
-  - Any Windows 10 version: using WSL2 container backend **(recommended)**
+- Windows 10 64-bit: (Build 18362 or later)
+  - WSL2 container backend
 
-If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education [here](https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/) though this is not required if you use WSL2 for containers.
+> **Optional:** If you are using Windows 10 Home, you can obtain a "free" license for Windows 10 Education [here](https://viterbiit.usc.edu/services/hardware-software/microsoft-imagine-downloads/) though this is not required.
 
 [Mac host](https://docs.docker.com/docker-for-mac/install/):
 
-- Mac hardware must be a 2010 or newer model
-- macOS must be version 10.13 or newer
-- 4 GB RAM minimum
+- Intel:
+  - Mac hardware must be a 2010 or newer model
+  - macOS must be version 10.13 or newer
+  - 4 GB RAM minimum
+- Apple Silicon (i.e. M1 chip):
+  - Rosetta emulated terminal
+    - for instructions on how to setup a Rosetta emulated terminal, see
+    [instructions
+    here](https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/)
+    to run Terminal through Rosetta.
 
-If you are using Apple Silicon, you should run the setup commands in a Rosetta emulation.
-See [instructions here](https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/) to run Terminal through Rosetta. However,
-be aware that gdb may not work per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
+> **Note:** gdb may not work on Apple Silicon per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
 
-## Setting Up
+### Step 0: Install WSL2 (Windows only)
 
-First, **install Docker** desktop from [the website](https://www.docker.com/products/docker-desktop).
-Once done, **clone this repository**, which contains a setup script for both Windows and Unix-based systems.
-Running it will install a helper CLI (command-line tool), pull the CSCI 104 docker image and setup a virtualized environment.
+If you are using macOS or Linux operating system, you can skip this section.
+If you are running Windows, you must install the Windows Subsystem for Linux 2 (WSL2) before installing Docker.
+
+Follow the instructions below to install WSL2 on your machine: [Windows Subsystem for Linux Installation Guide](https://docs.microsoft.com/windows/wsl/install-win10)
+
+
+### Step 1: Install Docker
+
+
+Install Docker Desktop from [the website](https://www.docker.com/products/docker-desktop).
+
+### Step 2: Clone this repository
+
+After setting up Docker you need to clone this repository which contains
+a setup script for both Windows and Unix-based systems.
+
+You can clone the repository with this command:
+
+```shell
+git clone git@github.com:csci104/docker.git
+```
+
+If this command fails with an error like `git command not found`, you need to
+install the git command-line interface (CLI). See [this link](https://git-scm.com/downloads) and download
+the package for your operating system.
+
+### Step 3: Run the setup script
+
+This repository contains a setup script to install a command-line tool you will
+use to access your Docker containers, pull the CSCI 104 docker image and setup your virtualized environment.
+
+To run the setup script, you need to open a Terminal or Powershell into the `docker` repository you cloned in [Step 2](#step-2-clone-this-repository).
+If you're not sure how to do that, see the [Getting a Filepath](#getting-a-filepath) tip.
+
+Now that you're ready to run the setup script, read and follow the instructions
+below corresponding to your operating system:
 
 **macOS/Linux**
 
@@ -62,7 +102,7 @@ Note: if you're not able to run `ch` after setup, you may need to run `source ~/
 
 **Windows**
 
-On Windows in PowerShell, the process is similar but you must make sure you can run PowerShell scripts:
+On Windows in PowerShell or Windows Terminal, the process is similar but you must make sure you can run PowerShell scripts:
 
 Make sure you run this in an Admin PowerShell:
 
@@ -77,12 +117,52 @@ In PowerShell, run this command in the `docker` folder:
 .\windows\setup
 ```
 
-When prompted, provide the directory in your local machine you wish to be accessible from the virtual machine.
-For example, if you cloned your homework directory to `/Users/username/Documents/hw-username` or `C:\Users\username\Documents\hw-username`, enter that.
-**You must supply the absolute path of the directory you want to access**.
-Something like `cs104/` or `../` is not sufficient, the path must start from `/` on Unix or `C:\` (or whatever disk you're working from) on Windows.
+### Step 4: Set your working directory
 
-Once you've finished answering the prompts and setup script finishes, you should be ready to use `ch` to work with your csci104 environment. Remember that if `ch` isn't available, you may need to run `source ~/.zshrc` or `source ~/.bashrc` on macOS. 
+If the command above runs successfully, you will be prompted to provide the directory in your local machine you wish to be accessible from the virtual machine.
+
+We highly recommend that you create a specific `csci104` folder where you will clone the required
+repositories and complete your programming assignments for the class.
+
+If you made your `csci104` folder in your home directory, the path will look something like
+this: `/Users/username/csci104` (macOS) or `C:\Users\username\csci104` (Windows).
+
+To get the filepath to this folder, you can drag the `csci104` folder into your terminal from Finder/Explorer. See the [Getting a Filepath](#getting-a-filepath) tip for more help.
+
+
+### Step 5: Verify your installation
+
+Once you've finished answering the prompts and setup script finishes, you should be ready to use `ch` to work with your csci104 environment!
+
+> If you're on macOS, try running `source ~/.zshrc` or `source ~/.bashrc` and then run `ch list`.
+If this fails, try opening up a new terminal and retry the command. If this fails, you can
+ask a CP, post on Piazza, or [create a Github Issue](https://github.com/csci104/docker/issues/new/choose) if you're not in the class but still need help.
+
+Let's check and make sure everything works by running `ch list` in your terminal.
+You should get output like this below:
+
+**macOS**
+
+```shell
+$ ch list
+Name:   csci104
+        Image:  usccsci104/docker:20.04
+        Volume: /Users/username/csci104:/work
+        SecOpt: seccomp:unconfined
+        CapAdd: SYS_PTRACE
+```
+
+**Windows**
+
+```powershell
+PS C:\Users\Username> ch list
+Name:   csci104
+        Image:  usccsci104/docker:20.04
+        Volume: C:\Users\Username\csci104:/work
+        SecOpt: seccomp:unconfined
+        CapAdd: SYS_PTRACE
+```
+
 
 ## Working
 
@@ -119,12 +199,32 @@ ch shell csci104
 ch stop csci104
 ```
 
-### Note: Valgrind Suppression
+## Tips
+
+### Getting a Filepath
+
+For the installation script and when navigating your terminal for the first time,
+you might need to provide a filepath. This represents "where" on your machine
+a specific folder or file is located.
+
+There are many ways to do this, but this seems like the easiest way for
+people getting used to using their terminal:
+
+1. open Finder (macOS) or Explorer (Windows)
+2. find the folder where you want to go to
+3. drag the path into your terminal to get the path
+
+If you're wanting to change directories like in [Step 2](#step-2-clone-this-repository), you'll type "cd " into your terminal and
+drag the folder in.
+
+If you're running the setup script in [Step 3](#step-3-run-the-setup-script), you will drag your csci104 folder in the terminal
+when the script asks for a filepath.
+### Valgrind Suppression
 
 To determine the correct valgrind suppression in the future, refer to [this manual](https://wiki.wxwidgets.org/Valgrind_Suppression_File_Howtohttps://wiki.wxwidgets.org/Valgrind_Suppression_File_Howto).
 Running it on a sufficiently complex piece of leak-free code will yield most of the necessary configurations.
 
-### Note: Hypervisor on Windows
+### Hypervisor on Windows
 
 If you plan to using Docker and Virtual Box as a fallback, please be aware of what you will need to do to switch between the two systems. You'll have to toggle the Hypervisor:
 


### PR DESCRIPTION
This PR rewrites the README to include more explicit installation instructions after feedback from students on Lab 0/1.

The goal of the rewrite:

* Make installation steps completely self-contained (no links to changing lab 0/1 instructions)
* Instructions should be sufficient to guide a student without any terminal experience
* Maintain readability, brevity (not sure I did the latter though)