### PR TITLE
install arm64 version of ch if possible

### DIFF
--- a/unix/install-ch.sh
+++ b/unix/install-ch.sh
@@ -82,6 +82,8 @@ version=$(get_latest_release $repository)
 zip_filename=
 if [ "$(uname)" = "Linux" ]; then
   zip_filename="ch-linux-amd64.zip"
+elif [ "$(uname -m)" = "arm64" ]; then
+  zip_filename="ch-darwin-arm64.zip"
 else
   zip_filename="ch-darwin-amd64.zip"
 fi


### PR DESCRIPTION
## Purpose
Noticed that an `arm64` version of `ch` is available, so I updated the install script to pull that version if a user's Terminal does return `arm64`. 

Works well with `csci104` image running in amd64 emulation.

I'm trying to put together a Docker image based on [arm64v8/ubuntu](https://hub.docker.com/r/arm64v8/ubuntu/) to see how much I can get working. I got stuck in figuring out what needs to be in `CMakeLists.txt`, but will file a separate issue. 