### PR TITLE
Support Apple and Linux arm64 architecture for #19

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -14,6 +14,9 @@ jobs:
         name: Check out the repo
         uses: actions/checkout@v2
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -21,5 +24,10 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: |-
+              linux/amd64
+              linux/arm64
           file: ./Dockerfile
           pull: true
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - multi-arch
 
 jobs:
   push_to_registry:
@@ -36,9 +35,9 @@ jobs:
               linux/arm64
           file: ./Dockerfile
           push: true
-          tags: usccsci104/docker-multiarch:20.04
-          cache-from: type=registry,ref=usccsci104/docker-multiarch:buildcache
-          cache-to: type=registry,ref=usccsci104/docker-multiarch:buildcache,mode=max
+          tags: usccsci104/docker:20.04
+          cache-from: type=registry,ref=usccsci104/docker:buildcache
+          cache-to: type=registry,ref=usccsci104/docker:buildcache,mode=max
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -37,8 +37,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: usccsci104/docker-multiarch:20.04
-          cache-from: type=registry,ref=usccsci104/docker-multiarch:20.04
-          cache-to: type=inline
+          cache-from: type=registry,ref=usccsci104/docker-multiarch:buildcache
+          cache-to: type=registry,ref=usccsci104/docker-multiarch:buildcache,mode=max
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -9,11 +9,14 @@ on:
 jobs:
   push_to_registry:
     name: Push image to Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -
         name: Check out the repo
         uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -35,9 +35,10 @@ jobs:
               linux/amd64
               linux/arm64
           file: ./Dockerfile
-          pull: true
           push: true
           tags: usccsci104/docker-multiarch:20.04
+          cache-from: type=registry,ref=usccsci104/docker-multiarch:20.04
+          cache-to: type=inline
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - multi-arch
 
 jobs:
   push_to_registry:
@@ -27,10 +28,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           pull: true
           push: true
-          tags: usccsci104/docker:20.04
+          tags: usccsci104/docker-multiarch:20.04
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,7 +28,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: |-
+              linux/amd64
+              linux/arm64
           file: ./Dockerfile
           pull: true
           push: true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
   <img align="left" src="https://img.shields.io/docker/pulls/usccsci104/docker" />
 </a>
 
+<a>
+  <img align="left" alt="Docker Image Version (latest semver)" src="https://img.shields.io/docker/v/usccsci104/docker">
+</a>
+
+<a>
+  <img align="left" alt="Supported Platforms" src="https://img.shields.io/badge/buildx%20platforms-amd64%2C%20arm64-blue">
+</a>
+
 </br>
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -62,13 +62,8 @@ Please make sure that your machine meets the requirements for Docker Desktop, wh
   - Mac hardware must be a 2010 or newer model
   - macOS must be version 10.13 or newer
   - 4 GB RAM minimum
-- Apple Silicon (i.e. M1 chip):
-  - Rosetta emulated terminal
-    - for instructions on how to setup a Rosetta emulated terminal, see
-    <a href="https://osxdaily.com/2020/11/18/how-run-homebrew-x86-terminal-apple-silicon-mac/" target="_blank">instructions here</a>
-    to run Terminal through Rosetta.
-
-> **Note:** The gdb debugger used in CSCI104 may not work on Apple Silicon per [this Github issue](https://github.com/docker/for-mac/issues/5191#issue-775028988).
+- Apple Silicon (e.g. M1, M1X chip):
+  - *note:* please **DO NOT** use a Rosetta-emulated terminal as arm64 architecture is fully supported
 
 ### Step 0: Install WSL2 (Windows only)
 


### PR DESCRIPTION
Add multi-architecture support for Docker image [usccsci104/docker](https://hub.docker.com/repository/docker/usccsci104/docker). 

Tested in [usccsci104/docker-multiarch](https://hub.docker.com/repository/docker/usccsci104/docker-multiarch) and documented in #19 (thanks @jurvis !)

### Apple Silicon
- Valgrind and GDB: https://github.com/csci104/docker/issues/19#issuecomment-980841505
- curricula: https://github.com/csci104/docker/issues/19#issuecomment-980842445

### Raspberry Pi 4 (Ubuntu Server 21.10 ARM 64-bit)

Shell:

```
ssh worker-arm-01
Welcome to Ubuntu 21.10 (GNU/Linux 5.13.0-1010-raspi aarch64)
...
cam@worker-arm-01:~$ ch shell csci104
root@docker:/work$ ls
cpp-sample/
```

GDB:

```
root@docker:/work$ cd cpp-sample
root@docker:/work/cpp-sample$ ls
4colortheorem80x80.txt  MinHeap.h  coloring      coloring.h    search      search.h
Makefile                README.md  coloring.cpp  curricula.sh  search.cpp
root@docker:/work/cpp-sample$ make
make: Nothing to be done for 'all'.
root@docker:/work/cpp-sample$ rm search coloring
root@docker:/work/cpp-sample$ make
g++ -Wall -g --std=c++11  search.cpp -o search
g++ -Wall -g --std=c++11 coloring.cpp -o coloring
root@docker:/work/cpp-sample$ gdb ./coloring
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2
...
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./coloring...
(gdb) b main
Breakpoint 1 at 0x1a70: file coloring.cpp, line 5.
(gdb) r 4colortheorem80x80.txt
Starting program: /work/cpp-sample/coloring 4colortheorem80x80.txt

Breakpoint 1, main (argc=2, argv=0xfffffffffce8) at coloring.cpp:5
5           if(argc < 2){
(gdb)

```

Valgrind:

```
root@docker:/work/cpp-sample$ valgrind ./coloring 4colortheorem80x80.txt
...
A 1
B 4
C 3
D 4
E 3
F 2
G 1
H 2
I 1
J 4

==133==
==133== HEAP SUMMARY:
==133==     in use at exit: 0 bytes in 0 blocks
==133==   total heap usage: 6,570 allocs, 6,570 frees, 349,920 bytes allocated
==133==
==133== All heap blocks were freed -- no leaks are possible
==133==
==133== For lists of detected and suppressed errors, rerun with: -s
==133== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```